### PR TITLE
2018 01 01 client - Remove references to deprecated RM nuget package

### DIFF
--- a/src/AzSdk.test.reference.props
+++ b/src/AzSdk.test.reference.props
@@ -4,7 +4,7 @@
     <PackageReference Include="Microsoft.Azure.Test.HttpRecorder" Version="[1.8.1,2.0.0)" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.7.1,2.0.0)" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure" Version="[3.3.10, 4.0.0)" /> 
-    <PackageReference Include="Microsoft.Azure.ResourceManager" Version="[1.1.0-preview]" />
+    <!--<PackageReference Include="Microsoft.Azure.ResourceManager" Version="[1.1.0-preview]" />-->
     
     <!-- This is needed for discovering tests in test explorer -->
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />	

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagementTestBase.cs
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagementTestBase.cs
@@ -4,18 +4,18 @@
 // 
 
 using System;
-using System.Linq;
-using Microsoft.Azure.Test.HttpRecorder;
-using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Azure.Management.ApiManagement;
 using Microsoft.Azure.Management.ApiManagement.Models;
-using Microsoft.Azure.Management.Resources;
-using Microsoft.Azure.Management.Resources.Models;
-using Microsoft.Azure.Management.Storage;
-using Microsoft.Azure.Management.Network;
-using Xunit;
 using Microsoft.Azure.Management.EventHub;
+using Microsoft.Azure.Management.Network;
+using Microsoft.Azure.Management.ResourceManager;
+using Microsoft.Azure.Management.ResourceManager.Models;
+using Microsoft.Azure.Management.Storage;
+using Microsoft.Azure.Test.HttpRecorder;
+using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
+using Xunit;
 
 namespace ApiManagement.Tests
 {


### PR DESCRIPTION
This is for running tests in Vsts